### PR TITLE
feat: have preview open left of nvim-tree if view.side == 'right'

### DIFF
--- a/lua/nvim-tree-preview/preview.lua
+++ b/lua/nvim-tree-preview/preview.lua
@@ -263,7 +263,7 @@ function Preview:get_win()
     height = math.min(config.max_height, math.max(config.min_height, math.ceil(height / 2))),
     row = math.max(0, vim.fn.screenrow() - 1),
     -- if view.side is 'right', then the preview window will be on the left of nvim-tree
-    col = (view_side == 'left' and vim.fn.winwidth(0) or -win_width) - 1,
+    col = (view_side == 'left' and vim.fn.winwidth(0) + 1 or -win_width - 3),
     relative = 'win',
   }
   if self.preview_win and vim.api.nvim_win_is_valid(self.preview_win) then

--- a/lua/nvim-tree-preview/preview.lua
+++ b/lua/nvim-tree-preview/preview.lua
@@ -256,11 +256,14 @@ end
 function Preview:get_win()
   local width = vim.api.nvim_get_option_value('columns', {})
   local height = vim.api.nvim_get_option_value('lines', {})
+  local view_side = require('nvim-tree').config.view.side
+  local win_width = math.min(config.max_width, math.max(config.min_width, math.ceil(width / 2)))
   local opts = {
-    width = math.min(config.max_width, math.max(config.min_width, math.ceil(width / 2))),
+    width = win_width,
     height = math.min(config.max_height, math.max(config.min_height, math.ceil(height / 2))),
     row = math.max(0, vim.fn.screenrow() - 1),
-    col = vim.fn.winwidth(0) + 1,
+    -- if view.side is 'right', then the preview window will be on the left of nvim-tree
+    col = (view_side == 'left' and vim.fn.winwidth(0) or -win_width) - 1,
     relative = 'win',
   }
   if self.preview_win and vim.api.nvim_win_is_valid(self.preview_win) then


### PR DESCRIPTION
I personally have nvim-tree open at the right side, so the previous floating preview would block items below the current node being hovered. Here's an example (the preview hides the rest of the items in the project directory):
![Screenshot 2024-10-13 at 12 23 58 PM](https://github.com/user-attachments/assets/03675f88-96a3-4361-8927-9a0354a2f7cd)

Instead, if `config.view.side == 'right'` (`config` deriving from the setup configs from `nvim-tree`, not this plugin), I calculate the `col` window offset differently so that the preview won't get in the way:
![Screenshot 2024-10-13 at 12 49 10 PM](https://github.com/user-attachments/assets/bf74d67f-9728-4641-a743-fb34f6bf2d6e)


Let me know what you think!