### PR TITLE
Fix #12: allow custom window position config

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,20 @@ require('nvim-tree-preview').setup {
   title_pos = 'top-left', -- top-left|top-center|top-right|bottom-left|bottom-center|bottom-right
   title_format = ' %s ',
   follow_links = true, -- Whether to follow symlinks when previewing files
+  -- win_position: { row?: number|function, col?: number|function }
+  -- Position of the preview window relative to the tree window.
+  -- If not specified, the position is automatically calculated.
+  -- Functions receive (tree_win, size) parameters and must return a number, where:
+  --   tree_win: number - tree window handle
+  --   size: {width: number, height: number} - dimensions of the preview window
+  -- Example:
+  --   win_position = {
+  --    col = function(tree_win, size)
+  --      local view_side = require('nvim-tree').config.view.side
+  --      return view_side == 'left' and vim.fn.winwidth(tree_win) + 1 or -size.width - 3
+  --    end,
+  --   },
+  win_position = {},
   image_preview = {
     enable = false, -- Whether to preview images (for more info see Previewing Images section in README)
     patterns = { -- List of Lua patterns matching image file names

--- a/lua/nvim-tree-preview/config.lua
+++ b/lua/nvim-tree-preview/config.lua
@@ -22,6 +22,7 @@ local M = {
     title_pos = 'top-center',
     title_format = ' %s ',
     follow_links = true,
+    win_position = {},
     image_preview = {
       enable = false,
       patterns = {

--- a/lua/nvim-tree-preview/config.lua
+++ b/lua/nvim-tree-preview/config.lua
@@ -59,6 +59,17 @@ local function setup(config)
   )
   assert(type(M.config.title_format) == 'string', 'title_format must be a string')
   assert(type(M.config.follow_links) == 'boolean', 'follow_links must be a boolean')
+  assert(type(M.config.win_position) == 'table', 'win_position must be a table')
+  assert(
+    M.config.win_position.row == nil
+      or (type(M.config.win_position.row) == 'number' or type(M.config.win_position.row) == 'function'),
+    'win_position.row must be a number, function returning a number, or nil'
+  )
+  assert(
+    M.config.win_position.col == nil
+      or (type(M.config.win_position.col) == 'number' or type(M.config.win_position.col) == 'function'),
+    'win_position.col must be a number, function returning a number, or nil'
+  )
   assert(type(M.config.on_open) == 'function' or M.config.on_open == nil, 'on_open must be a function or nil')
   assert(type(M.config.on_close) == 'function' or M.config.on_close == nil, 'on_close must be a function or nil')
   assert(type(M.config.image_preview) == 'table', 'image_preview must be a table')

--- a/lua/nvim-tree-preview/preview.lua
+++ b/lua/nvim-tree-preview/preview.lua
@@ -487,24 +487,21 @@ end
 ---@return {row: number, col: number} Calculated position
 function Preview:calculate_win_position(tree_win, size)
   local row, col
-  local calculate_row, calculate_col = true, true
 
   -- Check for user config first
   if config.win_position then
     if config.win_position.row ~= nil then
       row = type(config.win_position.row) == 'function' and config.win_position.row(tree_win, size)
         or config.win_position.row
-      calculate_row = false
     end
 
     if config.win_position.col ~= nil then
       col = type(config.win_position.col) == 'function' and config.win_position.col(tree_win, size)
         or config.win_position.col
-      calculate_col = false
     end
   end
 
-  if calculate_row or calculate_col then
+  if row == nil or col == nil then
     local view_side = require('nvim-tree').config.view.side
 
     -- Get cursor and window scroll information
@@ -515,7 +512,7 @@ function Preview:calculate_win_position(tree_win, size)
     -- Calculate cursor position relative to visible window
     local relative_cursor = cursor_row - topline
 
-    if calculate_row then
+    if row == nil then
       -- Get cursor position in screen coordinates
       local win_pos = vim.api.nvim_win_get_position(tree_win)
       local screen_row = win_pos[1] + relative_cursor
@@ -531,7 +528,7 @@ function Preview:calculate_win_position(tree_win, size)
       end
     end
 
-    if calculate_col then
+    if col == nil then
       -- Calculate column position based on tree side
       col = (view_side == 'left' and vim.fn.winwidth(tree_win) + 1 or -size.width - 3)
     end

--- a/lua/nvim-tree-preview/types.lua
+++ b/lua/nvim-tree-preview/types.lua
@@ -28,6 +28,10 @@
 ---@alias PreviewKeymap string|function|PreviewKeymapAction|{open: PreviewKeymapOpenDirection}
 ---@alias PreviewKeymapSpec {[1]: string, [2]: PreviewKeymap}
 
+---@class WindowPosition
+---@field row? number|fun(tree_win?: number, size?: {width: number, height: number}): number
+---@field col? number|fun(tree_win?: number, size?: {width: number, height: number}): number
+
 ---@class PreviewConfig
 ---@field keymaps {[string]: PreviewKeymap}
 ---@field min_width number
@@ -41,6 +45,7 @@
 ---@field title_pos 'top-left'|'top-center'|'top-right'|'bottom-left'|'bottom-center'|'bottom-right'
 ---@field title_format string
 ---@field follow_links boolean
+---@field win_position WindowPosition
 ---@field on_open? fun(win: number, buf: number)
 ---@field on_close? fun()
 ---@field image_preview {enable: boolean, patterns: string[]}


### PR DESCRIPTION
Hi,

I just recently discovered this plugin which I really like, partially as I also have been working on a preview plugin but for netrw.

I normally use a nvim-tree floating window, therefore this issue was relevant for me as well.

This PR basically allows for the user to optionally define the position of the preview window (either row, col, or both) with a number or a function that optionally accepts `tree_win` and/or `size`.

I think this approach is flexible to solve issues with floating nvim-tree windows based on user preferences.

For example, this is my nvim-tree config which float the window to the right:

```lua
view.float = {
        enable = true,
        quit_on_focus_loss = false,
        open_win_config = function()
          local screen_w = vim.opt.columns:get()
          local screen_h = vim.opt.lines:get() - vim.opt.cmdheight:get()
          -- local window_w = screen_w * 0.3
          local window_w = math.min(math.floor(screen_w * 0.28), 30)
          local window_h = screen_h * 0.9
          local window_w_int = math.floor(window_w)
          local window_h_int = math.floor(window_h)

          -- adjust for the offset
          local col_right_aligned = screen_w - window_w_int - 3
          local row_offset = 1

          return {
            border = "rounded",
            relative = "editor",
            row = row_offset,
            col = col_right_aligned,
            width = window_w_int,
            height = window_h_int,
          }
        end,
}
```

with this PR, I can add this configuration in your plugin, and positions the preview window nicely (I just modify the column position as the row is nicely calculated by your plugin):

```lua
  dependencies = {
    {
      "idr4n/nvim-tree-preview.lua",
      opts = {
        win_position = {
          ---@param tree_win number? The tree window handle
          ---@param size {width: number, height: number} Desired window dimensions
          ---@return number Calculated column position
          col = function(tree_win, size)
            return -1 * (size.width + 3)
          end,
        },
      },
    },
  },
```

![CleanShot 2025-07-05 at 07 06 05@2x](https://github.com/user-attachments/assets/93c5410e-fb1f-49ba-89ba-d573c5eb2ec0)

Let me know what you think, I would be happy to make any changes that you consider relevant or needed, in addition to updating the README at the end.

Thanks in advance!
