### PR TITLE
feat: add option to update preview on CursorHold

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ require('nvim-tree-preview').setup {
   },
   on_open = nil, -- fun(win: number, buf: number) called when the preview window is opened
   on_close = nil, -- fun() called when the preview window is closed
+  watch = {
+    enable_on_hold = false -- if true, update preview on CursorHold instead of immediately on CursorMoved
+  },
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ require('nvim-tree-preview').setup {
   on_open = nil, -- fun(win: number, buf: number) called when the preview window is opened
   on_close = nil, -- fun() called when the preview window is closed
   watch = {
-    enable_on_hold = false -- if true, update preview on CursorHold instead of immediately on CursorMoved
+    event = 'CursorMoved' -- 'CursorMoved'|'CursorHold'. Event to use to update the preview in watch mode
   },
 }
 ```

--- a/lua/nvim-tree-preview/config.lua
+++ b/lua/nvim-tree-preview/config.lua
@@ -36,6 +36,7 @@ local M = {
     },
     on_open = nil,
     on_close = nil,
+    watch = { enable_on_hold = false },
   },
 }
 
@@ -78,6 +79,8 @@ local function setup(config)
   for _, pattern in ipairs(M.config.image_preview.patterns) do
     assert(type(pattern) == 'string', 'image_preview.patterns must be a table of strings')
   end
+  assert(type(M.config.watch) == 'table', 'watch must be a table')
+  assert(type(M.config.watch.enable_on_hold) == 'boolean', 'watch.enable_on_hold must be a boolean')
 end
 
 return setmetatable({}, {

--- a/lua/nvim-tree-preview/config.lua
+++ b/lua/nvim-tree-preview/config.lua
@@ -36,7 +36,7 @@ local M = {
     },
     on_open = nil,
     on_close = nil,
-    watch = { enable_on_hold = false },
+    watch = { event = 'CursorMoved' },
   },
 }
 
@@ -80,7 +80,11 @@ local function setup(config)
     assert(type(pattern) == 'string', 'image_preview.patterns must be a table of strings')
   end
   assert(type(M.config.watch) == 'table', 'watch must be a table')
-  assert(type(M.config.watch.enable_on_hold) == 'boolean', 'watch.enable_on_hold must be a boolean')
+  assert(type(M.config.watch.event) == 'string', 'watch.event must be a string')
+  assert(
+    vim.tbl_contains({ 'CursorHold', 'CursorMoved' }, M.config.watch.event),
+    'watch.event must be one of CursorHold or CursorMoved'
+  )
 end
 
 return setmetatable({}, {

--- a/lua/nvim-tree-preview/manager.lua
+++ b/lua/nvim-tree-preview/manager.lua
@@ -96,7 +96,7 @@ function M.watch()
   if not M.instance or not M.instance:is_valid() then
     M.node_under_cursor()
   end
-  vim.api.nvim_create_autocmd({ config.watch.enable_on_hold and 'CursorHold' or 'CursorMoved' }, {
+  vim.api.nvim_create_autocmd(config.watch.event, {
     group = M.watch_augroup,
     buffer = M.watch_tree_buf,
     callback = function()

--- a/lua/nvim-tree-preview/manager.lua
+++ b/lua/nvim-tree-preview/manager.lua
@@ -1,6 +1,7 @@
 local api = require 'nvim-tree.api'
 
 local Preview = require 'nvim-tree-preview.preview'
+local config = require 'nvim-tree-preview.config'
 
 ---@class PreviewManager
 local M = {
@@ -95,7 +96,7 @@ function M.watch()
   if not M.instance or not M.instance:is_valid() then
     M.node_under_cursor()
   end
-  vim.api.nvim_create_autocmd({ 'CursorMoved' }, {
+  vim.api.nvim_create_autocmd({ config.watch.enable_on_hold and 'CursorHold' or 'CursorMoved' }, {
     group = M.watch_augroup,
     buffer = M.watch_tree_buf,
     callback = function()

--- a/lua/nvim-tree-preview/types.lua
+++ b/lua/nvim-tree-preview/types.lua
@@ -49,7 +49,7 @@
 ---@field on_open? fun(win: number, buf: number)
 ---@field on_close? fun()
 ---@field image_preview {enable: boolean, patterns: string[]}
----@field watch {enable_on_hold: boolean}
+---@field watch {event: 'CursorMoved'|'CursorHold'}
 
 ---@class PreviewConfigSetup: PreviewConfig
 

--- a/lua/nvim-tree-preview/types.lua
+++ b/lua/nvim-tree-preview/types.lua
@@ -49,6 +49,7 @@
 ---@field on_open? fun(win: number, buf: number)
 ---@field on_close? fun()
 ---@field image_preview {enable: boolean, patterns: string[]}
+---@field watch {enable_on_hold: boolean}
 
 ---@class PreviewConfigSetup: PreviewConfig
 


### PR DESCRIPTION
As suggested in your issue comment, I added a config option to the corresponding autocmd use `CursorHold` instead of `CursorMoved`.

Feel free to let me know if you want to change the name of the config option.

Closes #7